### PR TITLE
added facilitator select to individual lab

### DIFF
--- a/src/components/labs/Lab.js
+++ b/src/components/labs/Lab.js
@@ -3,17 +3,28 @@ import { useParams } from "react-router-dom"
 
 export const Lab = () => {
     const [ lab, singleLab ] = useState({})
+    const [ facilitator, selectFacilitator] = useState([])
 
     const { labId } = useParams()
 
     useEffect (
         () => {
             return fetch(`http://localhost:8088/labs/${labId}?_expand=facilitator`)
-            .then(response => response.json())
-            .then((data) => {
-                singleLab(data)
+                .then(response => response.json())
+                .then((data) => {
+                    singleLab(data)
             })
         },[ labId ]
+    )
+
+    useEffect (
+        () => {
+            return fetch("http://localhost:8088/facilitators")
+                .then(response => response.json())
+                .then((data) => {
+                    selectFacilitator(data)
+                })
+        }, []
     )
 
     return (
@@ -25,7 +36,20 @@ export const Lab = () => {
                 <div className="lab__address">{ lab.address }</div>
                 <div className="lab__date">{ lab.date }</div>
                 <div className="lab__time">{ lab.time }</div>
-                <div className="lab__facilitator">Facilitator will be: { lab.facilitator?.name }</div>
+                <div className="lab__facilitator">
+                    Facilitator will be: { lab.facilitator?.name }</div>
+                    <select id="facilitator">
+                        { 
+                            facilitator.map(
+                                (facilitator) => {
+                                    return <option key={`facilitator--${facilitator.id}`}>
+                                        { facilitator.name }
+                                    </option>
+                                }
+
+                            )
+                        }
+                    </select>
             </section>
         </>
     )


### PR DESCRIPTION
Changes Made

1. Create a useEffect for facillitators in Lab.js with an empty dependency array.
2. Create new state variable to hold array of facilitators.
3. return fetch call
4. select element in JSX with a map for facilitators names.

Steps to Review

Checkout this branch locally.

git fetch --all
git checkout ap-editLab

Open a new Terminal tab (⌘T) and navigate to the server directory.

Test app functionality.

- On the login page, enter a collaborators email address (ex: lilyrose@vanderbilt.edu)
- click sign in
- You should see the list of navbar links
- click on "LABs" and you should see a list of each lab name 
- click on a lab name to see the detail of that lab
- on the details view you should see a drop down under the current facilitator name assigned to the lab.
- the drop down menu should have all of the facilitators names in it

View code file.

Confirm file modifications are present as indicated above.
Confirm no unused code or extraneous comments exist.
